### PR TITLE
Made the Doom subprocess forward its standard output and standard err…

### DIFF
--- a/rocketlauncher2.cpp
+++ b/rocketlauncher2.cpp
@@ -439,6 +439,7 @@ void RocketLauncher2::on_pushButton_3_clicked() //RUN
     QFileInfo engineDir(enginefile);
     QDir::setCurrent(engineDir.absolutePath());
     process = new QProcess();
+    process->setProcessChannelMode(QProcess::ForwardedChannels);
 
     try
     {


### PR DESCRIPTION
…or to the parent rocketlauncher2 process so that error messages from the Doom process will not be lost.  This is especially helpful when dealing with potentially buggy mods.